### PR TITLE
Configure banned channels with an env variable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -599,7 +599,7 @@ export async function main() {
     process.exit(1);
   }
 
-  const slackClient = new SlackClient(botToken, bannedPostMessageChannels);
+  const slackClient = new SlackClient(botToken, bannedPostMessageChannels ?? '');
   let httpServer: any = null;
 
   // Setup graceful shutdown handlers

--- a/index.ts
+++ b/index.ts
@@ -52,12 +52,14 @@ interface GetUserProfileArgs {
 
 export class SlackClient {
   private botHeaders: { Authorization: string; "Content-Type": string };
+  private bannedPostMessageChannels: string[];
 
-  constructor(botToken: string) {
+  constructor(botToken: string, bannedChannelIds: string) {
     this.botHeaders = {
       Authorization: `Bearer ${botToken}`,
       "Content-Type": "application/json",
     };
+    this.bannedPostMessageChannels = bannedChannelIds.split(",").map((id: string) => id.trim());
   }
 
   async getChannels(limit: number = 100, cursor?: string): Promise<any> {
@@ -109,6 +111,13 @@ export class SlackClient {
   }
 
   async postMessage(channel_id: string, text: string): Promise<any> {
+    if (this.bannedPostMessageChannels.includes(channel_id)) {
+      return {
+        ok: false,
+        error: "Channel " + channel_id + " is in SLACK_BANNED_CHANNEL_IDS, not allowed to post",
+      };
+    }
+
     const response = await fetch("https://slack.com/api/chat.postMessage", {
       method: "POST",
       headers: this.botHeaders,
@@ -549,6 +558,7 @@ Options:
 
 Environment Variables:
   AUTH_TOKEN             Bearer token for HTTP authorization (fallback if --token not provided)
+  BANNED_POST_MESSAGE_CHANNELS     Comma-separated list of channel IDs to ban slack_post_message from, e.g. "C4QDRD22MV,C013X9UMR2"
 
 Examples:
   node index.js                                    # Use stdio transport (default)
@@ -580,6 +590,7 @@ export async function main() {
   
   const botToken = process.env.SLACK_BOT_TOKEN;
   const teamId = process.env.SLACK_TEAM_ID;
+  const bannedPostMessageChannels = process.env.BANNED_POST_MESSAGE_CHANNELS;
 
   if (!botToken || !teamId) {
     console.error(
@@ -588,7 +599,7 @@ export async function main() {
     process.exit(1);
   }
 
-  const slackClient = new SlackClient(botToken);
+  const slackClient = new SlackClient(botToken, bannedPostMessageChannels);
   let httpServer: any = null;
 
   // Setup graceful shutdown handlers

--- a/tests/slack-mcp-server.test.ts
+++ b/tests/slack-mcp-server.test.ts
@@ -365,7 +365,7 @@ describe('createSlackServer', () => {
   test('createSlackServer returns server instance', async () => {
     const { createSlackServer, SlackClient } = await import('../index.js');
     
-    const mockSlackClient = new SlackClient('xoxb-test-token');
+    const mockSlackClient = new SlackClient('xoxb-test-token', 'C123456,C789012');
     const server = createSlackServer(mockSlackClient);
 
     // Just test that the server is created and defined
@@ -484,7 +484,7 @@ describe('HTTP Server', () => {
   test('SlackClient can be instantiated', async () => {
     const { SlackClient } = await import('../index.js');
     
-    const mockSlackClient = new SlackClient('xoxb-test-token');
+    const mockSlackClient = new SlackClient('xoxb-test-token', 'C123456,C789012');
     
     // Test that SlackClient is created successfully
     expect(mockSlackClient).toBeDefined();


### PR DESCRIPTION
Context: https://embark.atlassian.net/browse/SS-12498

In https://github.com/EmbarkStudios/src/blob/7da2f361ef2d06b6f783e495f4a529c6043c3078/clusters/llm/kagent/k8s/tool-servers/slack-mcp.yaml#L43, we will add a `BANNED_POST_MESSAGE_CHANNELS` env variable with the channels we want the MCP to not post top level messages to. Reactions and thread replies are still allowed.

Note: need help figuring out how to pack this into an image and running it, so not sure if it works!